### PR TITLE
Eliminate reloading of a whole blending point

### DIFF
--- a/src/WebsiteProvider/Api/ContentHandlers.cs
+++ b/src/WebsiteProvider/Api/ContentHandlers.cs
@@ -204,7 +204,7 @@ namespace WebsiteProvider
                         {
                             //we are inserting different app to WebsitePrivider
                             var page = sectionJson.Rows[index] as WrapperPage;
-                            if (page == null)
+                            if (page == null || page.WebTemplatePage.Data != null)
                             {
                                 page = GetConainterPage(requestUri);
                                 sectionJson.Rows[index] = page;

--- a/src/WebsiteProvider/Api/ContentHandlers.cs
+++ b/src/WebsiteProvider/Api/ContentHandlers.cs
@@ -203,20 +203,16 @@ namespace WebsiteProvider
                         else
                         {
                             //we are inserting different app to WebsitePrivider
-                            WrapperPage page;
-
-                            //uncommenting the below lines results in MergeJson producing invalid patches
-                            //it is good to fix it, so we reuse existing wrapped pages
-                            //page = sectionJson.Rows[index] as WrapperPage;
-                            //if (page == null) 
-                            //{
-                            page = GetConainterPage(requestUri);
-                            //}
+                            var page = sectionJson.Rows[index] as WrapperPage;
+                            if (page == null)
+                            {
+                                page = GetConainterPage(requestUri);
+                                sectionJson.Rows[index] = page;
+                            }
 
                             page.RequestUri = requestUri;
                             page.Reset();
                             page.MergeJson(json);
-                            sectionJson.Rows[index] = page;
                         }
                     }
                     index++;


### PR DESCRIPTION
For https://github.com/StarcounterPrefabs/Website/issues/50.
(based on `bugfix/double-replace-op` branch)