### PR TITLE
Fix starcounter-include selector in test

### DIFF
--- a/test/WebsiteProvider.Tests/Ui/BasePage.cs
+++ b/test/WebsiteProvider.Tests/Ui/BasePage.cs
@@ -67,7 +67,7 @@ namespace WebsiteProvider.Tests.Ui
 
         protected bool CheckForSurface(string searchingClassName)
         {
-            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//juicy-composition")));
+            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//starcounter-include[contains(@class,'website-surface')]/juicy-composition")));
             return shadowRoot.FindElements(By.ClassName(searchingClassName)).Any();
         }
     }


### PR DESCRIPTION
The selector in the test was not specific enough. It was catching the root `starcounter-include` added in https://github.com/Starcounter/level1/pull/4223, instead of the `starcounter-include` that contains the Website section.