### PR TITLE
Escape the request parameter

### DIFF
--- a/src/WebsiteProvider/Api/ContentHandlers.cs
+++ b/src/WebsiteProvider/Api/ContentHandlers.cs
@@ -99,6 +99,7 @@ namespace WebsiteProvider
 
             Handle.GET("/WebsiteProvider/partial/wrapper?uri={?}&response={?}", (string requestUri, string responseKey) =>
             {
+                requestUri = Uri.UnescapeDataString(requestUri);
                 Response currentResponse = ResponseStorage.Get(responseKey);
                 WebUrl webUrl = this.GetWebUrl(requestUri);
                 WebTemplate template = webUrl?.Template;
@@ -154,7 +155,8 @@ namespace WebsiteProvider
                             var responseKey = ResponseStorage.Put(response);
                             isWrapped = true;
 
-                            response = Self.GET($"/WebsiteProvider/partial/wrapper?uri={Uri.EscapeDataString(requestUri)}&response={responseKey}");
+                            var escapedRequestUri = Uri.EscapeDataString(requestUri);
+                            response = Self.GET($"/WebsiteProvider/partial/wrapper?uri={escapedRequestUri}&response={responseKey}");
 
                             ResponseStorage.Remove(responseKey);
                             wrapper = response.Resource as WrapperPage;

--- a/src/WebsiteProvider/Api/ContentHandlers.cs
+++ b/src/WebsiteProvider/Api/ContentHandlers.cs
@@ -154,7 +154,7 @@ namespace WebsiteProvider
                             var responseKey = ResponseStorage.Put(response);
                             isWrapped = true;
 
-                            response = Self.GET($"/WebsiteProvider/partial/wrapper?uri={requestUri}&response={responseKey}");
+                            response = Self.GET($"/WebsiteProvider/partial/wrapper?uri={Uri.EscapeDataString(requestUri)}&response={responseKey}");
 
                             ResponseStorage.Remove(responseKey);
                             wrapper = response.Resource as WrapperPage;


### PR DESCRIPTION
Fix for unescaped request parameter, resulting in an exception when the original URI contains `?` or `&`.

Before the fix:
![2017-06-09 15_07_18-localhost_8080_calendar_view month day 2017-06-09](https://user-images.githubusercontent.com/566463/26976940-5b2b4b0e-4d26-11e7-83bd-ea856cdf57fd.png)

After:
![2017-06-09 15_15_15-calendar](https://user-images.githubusercontent.com/566463/26976968-792d24ec-4d26-11e7-9f0c-536ff6553ce6.png)




