### PR TITLE
Fixed checking if handler is registered

### DIFF
--- a/src/WebsiteProvider/Api/MappingHandlers.cs
+++ b/src/WebsiteProvider/Api/MappingHandlers.cs
@@ -92,7 +92,7 @@ namespace WebsiteProvider
                 UnmapPinningRule(webMap);
             }
             Blender.UnmapUri(mapUri, token);
-            if (Handle.IsHandlerRegistered(mapUri, selfOnlyOptions))
+            if (Handle.IsHandlerRegistered("GET " + mapUri, selfOnlyOptions))
             {
                 Handle.UnregisterHttpHandler("GET", mapUri);
             }
@@ -100,7 +100,7 @@ namespace WebsiteProvider
 
         private void RegisterEmptyHandler(string uri)
         {
-            if (!Handle.IsHandlerRegistered(uri, selfOnlyOptions))
+            if (!Handle.IsHandlerRegistered("GET " + uri, selfOnlyOptions))
             {
                 Handle.GET(uri, () => new Json(), selfOnlyOptions);
             }

--- a/test/WebsiteProvider_AcceptanceHelperOne/Api/MainHandlers.cs
+++ b/test/WebsiteProvider_AcceptanceHelperOne/Api/MainHandlers.cs
@@ -50,13 +50,6 @@ namespace WebsiteProvider_AcceptanceHelperOne
                 return "Data for testing catching rules (without existing catch-all rules) is set";
             });
 
-            Handle.GET("/WebsiteProvider_AcceptanceHelperOne/ResetData", () =>
-            {
-                DataHelper.ResetData();
-                Handle.SetOutgoingStatusCode(200);
-                return "Catching rules are reseted";
-            });
-
             Handle.GET("/WebsiteProvider_AcceptanceHelperOne/SetupCatchingRuleWildcardTests", () =>
             {
                 DataHelper.SetCatchingRulesWithWildcards();


### PR DESCRIPTION
For https://github.com/StarcounterApps/Website/issues/108.
Also removed double registering of the "/WebsiteProvider_AcceptanceHelperOne/ResetData" URI - strange thing that in 2.3.1 it did not appear.