### PR TITLE
Pass along parameters to star (run.bat)

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -2,5 +2,5 @@
 
 IF "%CONFIGURATION%"=="" SET CONFIGURATION=Debug
 
-star --resourcedir="%~dp0src\Website\wwwroot" "%~dp0src\Website\bin\%CONFIGURATION%\Website.exe"
-star --resourcedir="%~dp0src\WebsiteProvider\wwwroot" "%~dp0src\WebsiteProvider\bin\%CONFIGURATION%\WebsiteProvider.exe"
+star %* --resourcedir="%~dp0src\Website\wwwroot" "%~dp0src\Website\bin\%CONFIGURATION%\Website.exe"
+star %* --resourcedir="%~dp0src\WebsiteProvider\wwwroot" "%~dp0src\WebsiteProvider\bin\%CONFIGURATION%\WebsiteProvider.exe"


### PR DESCRIPTION
Pass along parameters to star (run.bat); for Starcounter/Guidelines#31 .