### PR TITLE
Adaptation to new pattern for session and sessionstorage

### DIFF
--- a/src/WebsiteEditor/Api/CommitHooks.cs
+++ b/src/WebsiteEditor/Api/CommitHooks.cs
@@ -20,12 +20,22 @@ namespace WebsiteEditor
 
         protected void RefreshSignInState()
         {
+            if (Session.Current == null) 
+            {
+                return;
+            }
+
             Session.ScheduleTask(Session.Current.SessionId, (session, id) =>
             {
-                var page = Session.Current.Data as MasterPage;
+                if (session == null) // Session have timed out after the task was scheduled 
+                {
+                    return;
+                }
+
+                var page = session.Store[nameof(MasterPage)] as MasterPage;
 
                 page?.Transaction.Scope(() => page.RefreshCurrentPage());
-                Session.Current.CalculatePatchAndPushOnWebSocket();
+                session.CalculatePatchAndPushOnWebSocket();
             });
         }
     }

--- a/src/WebsiteEditor/Api/MainHandlers.cs
+++ b/src/WebsiteEditor/Api/MainHandlers.cs
@@ -131,21 +131,17 @@ namespace WebsiteEditor
 
         protected MasterPage GetMasterPageFromSession()
         {
-            if (Session.Current == null)
-            {
-                Session.Current = new Session(SessionOptions.PatchVersioning);
-            }
-
-            MasterPage master = Session.Current.Data as MasterPage;
+            MasterPage master = Session.Ensure().Store[nameof(MasterPage)] as MasterPage;
 
             if (master == null)
             {
                 master = new MasterPage();
-                Session.Current.Data = master;
+                Session.Current.Store[nameof(MasterPage)] = master;
             }
-
+ 
             return master;
         }
+
         private static void SetMasterCurrentPage(MasterPage master, string uri)
         {
             try

--- a/src/WebsiteProvider/Api/MappingHandlers.cs
+++ b/src/WebsiteProvider/Api/MappingHandlers.cs
@@ -73,14 +73,11 @@ namespace WebsiteProvider
 
             Blender.UnmapUri(webMapForeignUrl, token);
 
-            if (webMap.Url != null)
+            if (webMap.Url != null &&
+                Blender.ListByTokens()[token].Count == 2) // one URI for empty WebMap's handler and another one for empty WebSection's handler
             {
-                var uriByTokenCount = Blender.ListAll().Where(x => x.Key == token).SelectMany(x => x.Value).Count();
-                if (uriByTokenCount == 2) // one URI for empty WebMap's handler and another one for empty WebSection's handler
-                {
-                    Blender.UnmapUri(mapUri, token);
-                    Handle.UnregisterHttpHandler("GET", mapUri);
-                }
+                Blender.UnmapUri(mapUri, token);
+                Handle.UnregisterHttpHandler("GET", mapUri);
             }
         }
 
@@ -116,16 +113,15 @@ namespace WebsiteProvider
         private static string GetOldUri(WebMap webMap)
         {
             var token = webMap.GetMappingToken();
-            var actualMappings = Blender.ListAll().Where(x => x.Key == token).SelectMany(x => x.Value);
-            var newMappings = new List<string> { webMap.Section.GetMappingUrl() };
+            var currentMappingUrls = new List<string> {webMap.Section.GetMappingUrl()};
 
             foreach (WebMap map in webMap.Section.Maps)
             {
-                newMappings.Add(map.GetMappingUrl());
-                newMappings.Add(map.ForeignUrl);
+                currentMappingUrls.Add(map.GetMappingUrl());
+                currentMappingUrls.Add(map.ForeignUrl);
             }
 
-            return actualMappings.FirstOrDefault(x => !newMappings.Distinct().Contains(x));
+            return Blender.ListByTokens()[token].FirstOrDefault(x => !currentMappingUrls.Contains(x.Uri))?.Uri;
         }
     }
 }


### PR DESCRIPTION
This PR should be seen as a sample of the changes for sessions and storing viewmodels on session. A starcounter version with the changes in branch `feature/v2.3/78-139-4017` in `Starcounter/Level1` repo are needed (since that branch is not merged yet).

Included in these changes are also the changes in branch `blender-api-upgrade` to have the app build correcctly.

Implements: https://github.com/Starcounter/Home/issues/139

Before tomorrow this must be tested with a custom build: https://teamcity.starcounter.org/viewLog.html?buildId=27821&buildTypeId=Starcounter_V23NightlyWindows&tab=artifacts