### PR TITLE
Juicy-tile-tables was removed from Launchpad. Only the CSS rules from…

### DIFF
--- a/src/WebsiteEditor/wwwroot/WebsiteEditor/viewmodels/AppIcon.html
+++ b/src/WebsiteEditor/wwwroot/WebsiteEditor/viewmodels/AppIcon.html
@@ -1,3 +1,3 @@
 ﻿<template>
-    <img slot="websiteeditor/app-icon" src="/WebsiteEditor/images/websiteeditor.png" style="width: 100%; height: 100%" />
+    <img slot="websiteeditor/app-icon" src="/WebsiteEditor/images/websiteeditor.png" />
 </template>


### PR DESCRIPTION
… Launchpad should be applied.

Releted to https://github.com/StarcounterApps/Launchpad/pull/16 .