### PR TITLE
Fixed error when mapping duplicated pinning rules

### DIFF
--- a/src/WebsiteProvider/Api/PinningHandlers.cs
+++ b/src/WebsiteProvider/Api/PinningHandlers.cs
@@ -92,7 +92,7 @@ namespace WebsiteProvider.Api
             if (!Blender.IsMapped(callerUri, token))
             {
                 this.RegisterEmptyHandler(callerUri);
-                Blender.MapUri(callerUri, token);
+                Blender.MapUri(callerUri, token, true, false);
             }
 
             if (mapInfo.UseCustomCatchingRule)
@@ -104,7 +104,7 @@ namespace WebsiteProvider.Api
                 {
                     if (!Blender.IsMapped(info.ForeignUri, token))
                     {
-                        Blender.MapUri(info.ForeignUri, token);
+                        Blender.MapUri(info.ForeignUri, token, false, true);
                     }
                 }
             }
@@ -117,13 +117,13 @@ namespace WebsiteProvider.Api
                 {
                     if (!Blender.IsMapped(webMap.ForeignUrl, otherTokens))
                     {
-                        Blender.MapUri(webMap.ForeignUrl, otherTokens);
+                        Blender.MapUri(webMap.ForeignUrl, otherTokens, false, true);
                     }
                 }
             }
 
             // now do map current Pinning Rule's URI to the current token and save mapping info
-            Blender.MapUri(webMap.ForeignUrl, token);
+            Blender.MapUri(webMap.ForeignUrl, token, false, true);
 
             this.AddMappingInfo(mapInfo);
         }

--- a/src/WebsiteProvider/Api/PinningHandlers.cs
+++ b/src/WebsiteProvider/Api/PinningHandlers.cs
@@ -10,7 +10,7 @@ namespace WebsiteProvider.Api
     /// <summary>
     /// Do mapping/unmapping of the Pinning Rules
     /// </summary>
-    public class PinningHandlers
+    public partial class PinningHandlers
     {
         private static PinningHandlers instance;
         private bool isRegistered;
@@ -261,62 +261,6 @@ namespace WebsiteProvider.Api
             if (!isExpectedRegistered && isRegistered)
             {
                 throw new InvalidOperationException("Mappings is already registered.");
-            }
-        }
-
-        /// <summary>
-        /// Summary info for Pinning Rule mapping
-        /// </summary>
-        private class PinningRuleMappingInfo
-        {
-            public List<ulong> MapIds { get; set; }
-            public ulong SectionId { get; set; }
-            public ulong TemplateId { get; set; }
-
-            public bool UseCustomCatchingRule { get; set; }
-
-            public string CallerUri { get; set; }
-            public string ForeignUri { get; set; }
-            public string Token { get; set; }
-            public string TokenBase { get; set; }
-        }
-
-        private class PinningRulesMappingCollection
-        {
-            private readonly object locker = new object();
-            private readonly List<PinningRuleMappingInfo> mappingInfos = new List<PinningRuleMappingInfo>();
-
-            public void Add(PinningRuleMappingInfo info)
-            {
-                lock (locker)
-                {
-                    this.mappingInfos.Add(info);
-                }
-            }
-
-            public List<PinningRuleMappingInfo> Take(Func<PinningRuleMappingInfo, bool> predicate)
-            {
-                lock (locker)
-                {
-                    var items = this.mappingInfos.Where(predicate).ToList();
-                    foreach (var info in items)
-                    {
-                        if (info.MapIds.Count <= 1)
-                        {
-                            this.mappingInfos.Remove(info);
-                        }
-                    }
-                    return items;
-                }
-            }
-
-            public void Process(Func<PinningRuleMappingInfo, bool> predicate, Action<List<PinningRuleMappingInfo>> action)
-            {
-                lock (locker)
-                {
-                    var items = this.mappingInfos.Where(predicate).ToList();
-                    action(items);
-                }
             }
         }
     }

--- a/src/WebsiteProvider/Api/PinningRuleMappingInfo.cs
+++ b/src/WebsiteProvider/Api/PinningRuleMappingInfo.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace WebsiteProvider.Api
+{
+    public partial class PinningHandlers
+    {
+        /// <summary>
+        /// Summary info for Pinning Rule mapping
+        /// </summary>
+        private class PinningRuleMappingInfo
+        {
+            public List<ulong> MapIds { get; set; }
+            public ulong SectionId { get; set; }
+            public ulong TemplateId { get; set; }
+
+            public bool UseCustomCatchingRule { get; set; }
+
+            public string CallerUri { get; set; }
+            public string ForeignUri { get; set; }
+            public string Token { get; set; }
+            public string TokenBase { get; set; }
+        }
+    }
+}

--- a/src/WebsiteProvider/Api/PinningRulesMappingCollection.cs
+++ b/src/WebsiteProvider/Api/PinningRulesMappingCollection.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebsiteProvider.Api
+{
+    public partial class PinningHandlers
+    {
+        private class PinningRulesMappingCollection
+        {
+            private readonly object locker = new object();
+            private readonly List<PinningRuleMappingInfo> mappingInfos = new List<PinningRuleMappingInfo>();
+
+            public void Add(PinningRuleMappingInfo info)
+            {
+                lock (locker)
+                {
+                    this.mappingInfos.Add(info);
+                }
+            }
+
+            public List<PinningRuleMappingInfo> Take(Func<PinningRuleMappingInfo, bool> predicate)
+            {
+                lock (locker)
+                {
+                    var items = this.mappingInfos.Where(predicate).ToList();
+                    foreach (var info in items)
+                    {
+                        if (info.MapIds.Count <= 1)
+                        {
+                            this.mappingInfos.Remove(info);
+                        }
+                    }
+                    return items;
+                }
+            }
+
+            public void Process(Func<PinningRuleMappingInfo, bool> predicate, Action<List<PinningRuleMappingInfo>> action)
+            {
+                lock (locker)
+                {
+                    var items = this.mappingInfos.Where(predicate).ToList();
+                    action(items);
+                }
+            }
+        }
+    }
+}

--- a/src/WebsiteProvider/WebsiteProvider.csproj
+++ b/src/WebsiteProvider/WebsiteProvider.csproj
@@ -67,6 +67,8 @@
     <Compile Include="Api\CommitHooks.cs" />
     <Compile Include="Api\ContentHandlers.cs" />
     <Compile Include="Api\PinningHandlers.cs" />
+    <Compile Include="Api\PinningRuleMappingInfo.cs" />
+    <Compile Include="Api\PinningRulesMappingCollection.cs" />
     <Compile Include="Helpers\Storage.cs" />
     <Compile Include="Helpers\MappingExtensions.cs" />
     <Compile Include="Program.cs" />

--- a/test/WebsiteProvider.Tests/Test/PinningRulesMappingTests.cs
+++ b/test/WebsiteProvider.Tests/Test/PinningRulesMappingTests.cs
@@ -28,7 +28,7 @@ namespace WebsiteProvider.Tests.Test
         [SetUp]
         public void SetUpFixture()
         {
-            Driver.Navigate().GoToUrl(Config.AcceptanceHelperOneUrl + "/ResetData");
+            this.ResetData();
             Driver.Navigate().GoToUrl(Config.AcceptanceHelperOneUrl + "/SetupPinningRulesMappingTests");
         }
 
@@ -306,6 +306,48 @@ namespace WebsiteProvider.Tests.Test
             Assert.AreEqual(0, topPins.Count);
             Assert.AreEqual(2, mainPins.Count);
             WaitUntil(x => mainPins.All(p => expectedMainPinsContent.Contains(p.Text)));
+        }
+
+        /// <summary>
+        /// 1) Duplicate one pinning rule, load page and check that duplication is not affected on mapping.
+        /// 2) Delete one duplicated pinning rule, load page and check that deleted one is not affected on mapping.
+        /// 2) Deletу the second duplicated pinning rule, load page and check that pinning rule's content is not blended.
+        /// </summary>
+        [Test]
+        public void RequestPage_PinningRuleDiplicatedAndDeleted_TheMappingIsNotAffectedOnDuplication()
+        {
+            Driver.Navigate().GoToUrl(Config.AcceptanceHelperOneUrl + "/pin/2/duplicate");
+
+            for (int i = 0; i < 2; i++)
+            {
+                var page = new AcceptanceHelperOneMasterPage(Driver).LoadSimplePage();
+                WaitForText(page.HeaderElement, "Simple Page");
+
+                var topPins = this.GetTopBarPins();
+                var mainPins = this.GetMainPins();
+                var expectedTopPinsContent = new[] { "Pin 1", "Pin 2", "Pin 3" };
+                var expectedMainPinsContent = new[] { "Pin 6", "Pin 7" };
+
+                Assert.AreEqual(3, topPins.Count);
+                Assert.AreEqual(2, mainPins.Count);
+                WaitUntil(x => topPins.All(p => expectedTopPinsContent.Contains(p.Text)));
+                WaitUntil(x => mainPins.All(p => expectedMainPinsContent.Contains(p.Text)));
+
+                Driver.Navigate().GoToUrl(Config.AcceptanceHelperOneUrl + "/pin/2/delete");
+            }
+
+            var page2 = new AcceptanceHelperOneMasterPage(Driver).LoadSimplePage();
+            WaitForText(page2.HeaderElement, "Simple Page");
+
+            var topPins2 = this.GetTopBarPins();
+            var mainPins2 = this.GetMainPins();
+            var expectedTopPinsContent2 = new[] { "Pin 1", "Pin 3" };
+            var expectedMainPinsContent2 = new[] { "Pin 6", "Pin 7" };
+
+            Assert.AreEqual(2, topPins2.Count);
+            Assert.AreEqual(2, mainPins2.Count);
+            WaitUntil(x => topPins2.All(p => expectedTopPinsContent2.Contains(p.Text)));
+            WaitUntil(x => mainPins2.All(p => expectedMainPinsContent2.Contains(p.Text)));
         }
 
         private ICollection<IWebElement> GetTopBarPins()

--- a/test/WebsiteProvider_AcceptanceHelperOne/Api/MainHandlers.cs
+++ b/test/WebsiteProvider_AcceptanceHelperOne/Api/MainHandlers.cs
@@ -97,6 +97,20 @@ namespace WebsiteProvider_AcceptanceHelperOne
                 }
             });
 
+            Handle.GET("/WebsiteProvider_AcceptanceHelperOne/pin/{?}/duplicate", (string pinId) =>
+            {
+                if (this.DataHelper.DuplicateWebMap(pinId))
+                {
+                    Handle.SetOutgoingStatusCode(200);
+                    return "Pinning rule duplicated";
+                }
+                else
+                {
+                    Handle.SetOutgoingStatusCode(404);
+                    return "Pinning rule is not found";
+                }
+            });
+
             Handle.GET("/WebsiteProvider_AcceptanceHelperOne/pin/{?}/change-url", (string pinId) =>
             {
                 if (this.DataHelper.ChangeWebMapUrl(pinId))

--- a/test/WebsiteProvider_AcceptanceHelperOne/Helpers/DataHelper.cs
+++ b/test/WebsiteProvider_AcceptanceHelperOne/Helpers/DataHelper.cs
@@ -245,6 +245,26 @@ namespace WebsiteProvider_AcceptanceHelperOne
             return isEdited;
         }
 
+        public bool DuplicateWebMap(string pinningRuleId)
+        {
+            bool isDuplicated = false;
+            Db.Transact(() =>
+            {
+                var webMap = Db.SQL<WebMap>("SELECT m FROM Simplified.Ring6.WebMap m WHERE m.ForeignUrl = ?", "/WebsiteProvider_AcceptanceHelperTwo/pin" + pinningRuleId).FirstOrDefault();
+                if (webMap != null)
+                {
+                    new WebMap
+                    {
+                        Url = webMap.Url,
+                        Section = webMap.Section,
+                        ForeignUrl = webMap.ForeignUrl
+                    };
+                    isDuplicated = true;
+                }
+            });
+            return isDuplicated;
+        }
+
         public bool RenewWebSectionForPinningRules(string sectionId)
         {
             bool isUpdated = false;


### PR DESCRIPTION
For https://github.com/StarcounterApps/Website/issues/139.

With this fix user can save duplicated pinning rules, but it will not affect on its mapping. It is supposed that in future WebsiteEditor will have user notification feature implemented and WebsiterEditor will not allow to save duplicated pinning rules. But still in such case this fix will be required.