### PR TITLE
Removed unassigned group

### DIFF
--- a/src/WebsiteEditor/Helpers/DataHelper.cs
+++ b/src/WebsiteEditor/Helpers/DataHelper.cs
@@ -28,30 +28,18 @@ namespace WebsiteEditor.Helpers
             Db.Transact(() =>
             {
                 ClearData();
-                var unassignedGroup = GenerateGroups();
-                GenerateDefaultSurface(unassignedGroup);
-                GenerateSidebarSurface(unassignedGroup);
-                GenerateHolyGrailSurface(unassignedGroup);
+                GenerateDefaultSurface();
+                GenerateSidebarSurface();
+                GenerateHolyGrailSurface();
             });
         }
 
-        public WebTemplateGroup GenerateGroups()
-        {
-            var unassigned = new WebTemplateGroup
-            {
-                Name = "Unassigned"
-            };
-
-            return unassigned;
-        }
-
-        public void GenerateDefaultSurface(WebTemplateGroup group)
+        public void GenerateDefaultSurface()
         {
             var surface = new WebTemplate
             {
                 Name = "DefaultSurface",
-                Html = "/websiteprovider/surfaces/DefaultSurface.html",
-                WebTemplateGroup = group
+                Html = "/websiteprovider/surfaces/DefaultSurface.html"
             };
 
             var topbar = new WebSection
@@ -78,13 +66,12 @@ namespace WebsiteEditor.Helpers
             new WebMap { Section = topbar, ForeignUrl = "/signin/user", SortNumber = 1 };
         }
 
-        public void GenerateSidebarSurface(WebTemplateGroup group)
+        public void GenerateSidebarSurface()
         {
             var surface = new WebTemplate
             {
                 Name = "SidebarSurface",
-                Html = "/websiteprovider/surfaces/SidebarSurface.html",
-                WebTemplateGroup = group
+                Html = "/websiteprovider/surfaces/SidebarSurface.html"
             };
 
             var sidebarLeft = new WebSection
@@ -110,13 +97,12 @@ namespace WebsiteEditor.Helpers
             new WebMap { Url = templatesUrl, Section = sidebarLeft, ForeignUrl = "/websiteprovider/help?topic=surfaces", SortNumber = 1 };
         }
 
-        public void GenerateHolyGrailSurface(WebTemplateGroup group)
+        public void GenerateHolyGrailSurface()
         {
             var surface = new WebTemplate
             {
                 Name = "HolyGrailSurface",
-                Html = "/websiteprovider/surfaces/HolyGrailSurface.html",
-                WebTemplateGroup = group
+                Html = "/websiteprovider/surfaces/HolyGrailSurface.html"
             };
 
             var content = new WebSection

--- a/src/WebsiteEditor/ViewModels/GeneralPage.json.cs
+++ b/src/WebsiteEditor/ViewModels/GeneralPage.json.cs
@@ -20,7 +20,7 @@ namespace WebsiteEditor.ViewModels
             this.BlendingPoints.Data = Db.SQL<WebSection>("SELECT s FROM Simplified.Ring6.WebSection s WHERE s.Template = ? ORDER BY s.Template.Name, s.Name", this.Surface.Data);
             this.SurfaceGroups.Data = Db.SQL<WebTemplateGroup>("SELECT g FROM Simplified.Ring6.WebTemplateGroup g ORDER BY g.Name");
 
-            this.CurrentGroupKey = this.Surface.Data.WebTemplateGroup.Key;
+            this.CurrentGroupKey = this.Surface.Data.WebTemplateGroup?.Key;
             this.DefaultBlendingPointKey = this.BlendingPoints.FirstOrDefault(x => x.Default)?.Key;
             this.Trn.Data = this.Transaction as Transaction;
         }

--- a/src/WebsiteEditor/ViewModels/SurfaceGroupsPage.json
+++ b/src/WebsiteEditor/ViewModels/SurfaceGroupsPage.json
@@ -2,7 +2,7 @@
   "Html": "/WebsiteEditor/viewmodels/SurfaceGroupsPage.html",
   "SurfaceGroups$": [
     {
-      "Name$": "", 
+      "Name$": "",
       "CreateSurface$": 0,
       "DeleteGroup$": 0,
       "Surfaces": [
@@ -15,6 +15,14 @@
       ]
     }
   ],
-
+  "UnassignedSurfaces": [
+    {
+      "Key": "",
+      "Name": "",
+      "Html$": "",
+      "Select$": 0
+    }
+  ],
+  "CreateUnassignedSurface$": 0, 
   "CreateGroup$": 0 
 }

--- a/src/WebsiteEditor/ViewModels/SurfaceGroupsPage.json.cs
+++ b/src/WebsiteEditor/ViewModels/SurfaceGroupsPage.json.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Simplified.Ring6;
 using Starcounter;
 
@@ -9,6 +10,7 @@ namespace WebsiteEditor.ViewModels
         {
             this.SurfaceGroups.Clear();
             this.SurfaceGroups.Data = Db.SQL<WebTemplateGroup>("SELECT g FROM Simplified.Ring6.WebTemplateGroup g ORDER BY g.Name");
+            this.UnassignedSurfaces.Data = Db.SQL<WebTemplate>("SELECT wt FROM Simplified.Ring6.WebTemplate wt  WHERE wt.WebTemplateGroup IS NULL ORDER BY wt.Name");
         }
 
         void Handle(Input.CreateGroup action)
@@ -19,6 +21,19 @@ namespace WebsiteEditor.ViewModels
             });
 
             this.RefreshData();
+        }
+
+        void Handle(Input.CreateUnassignedSurface action)
+        {
+            Db.Transact(() =>
+            {
+                this.UnassignedSurfaces.Add().Data = new WebTemplate
+                {
+                    Name = "New surface"
+                };
+            });
+
+            RefreshData();
         }
 
         [SurfaceGroupsPage_json.SurfaceGroups]
@@ -54,19 +69,14 @@ namespace WebsiteEditor.ViewModels
 
             void Handle(Input.DeleteGroup action)
             {
-                var unassignedGroupName = "Unassigned";
-
                 var surfaces =
                     Db.SQL<WebTemplate>(
                         "SELECT w FROM Simplified.Ring6.WebTemplate w WHERE w.WebTemplateGroup = ?", this.Data);
 
-                var unassignedGroup =
-                    Db.SQL<WebTemplateGroup>($"SELECT g FROM Simplified.Ring6.WebTemplateGroup g WHERE g.Name = ?", unassignedGroupName).First;
-
-                // Move surfaces from this group to unassigned.
+                // Make surfaces unassigned.
                 foreach (var surface in surfaces)
                 {
-                    (surface as WebTemplate).WebTemplateGroup = unassignedGroup;
+                    (surface as WebTemplate).WebTemplateGroup = null;
                 }
 
                 this.Data.Delete();

--- a/src/WebsiteEditor/wwwroot/WebsiteEditor/viewmodels/GeneralPage.html
+++ b/src/WebsiteEditor/wwwroot/WebsiteEditor/viewmodels/GeneralPage.html
@@ -13,14 +13,14 @@
         </div>
         <div class="website-general-section">
             <p>Surface group:</p>
-            <juicy-select value="{{model.CurrentGroupKey$}}" options="{{model.SurfaceGroups}}" text-property="Name" value-property="Key">
+            <juicy-select caption-text="Unassigned" value="{{model.CurrentGroupKey$}}" options="{{model.SurfaceGroups}}" text-property="Name" value-property="Key">
                 <select class="website-select"></select>
             </juicy-select>
 
         </div>
         <div class="website-general-section">
             <p>Default blending point:</p>
-            <juicy-select caption-text=" " value="{{model.DefaultBlendingPointKey$}}" options="{{model.BlendingPoints}}" text-property="Name" value-property="Key">
+            <juicy-select caption-text="None" value="{{model.DefaultBlendingPointKey$}}" options="{{model.BlendingPoints}}" text-property="Name" value-property="Key">
                 <select class="website-select"></select>
             </juicy-select>
 

--- a/src/WebsiteEditor/wwwroot/WebsiteEditor/viewmodels/SurfaceGroupsPage.html
+++ b/src/WebsiteEditor/wwwroot/WebsiteEditor/viewmodels/SurfaceGroupsPage.html
@@ -6,27 +6,32 @@
         <br />
         <template is="dom-repeat" items="{{model.SurfaceGroups$}}">
             <h4>
-                <template is="dom-if" if="{{!isUnassignedGroup(item.Name$)}}">
-                    <input type="text" value="{{item.Name$::change}}" class="website-surface-group-name" />
-                </template>
-                <template is="dom-if" if="{{isUnassignedGroup(item.Name$)}}">
-                    <label class="website-surface-group-name">{{item.Name$}}</label>
-                </template>
-
+                <input type="text" value="{{item.Name$::change}}" class="website-surface-group-name"/>
                 <button class="btn website-surface-groups-add btn-success" title="Add new surface" value="{{item.CreateSurface$::click}}" onmousedown="++this.value;">
                     <span class="glyphicon glyphicon-plus website-no-pointer-events"></span>
                 </button>
-                <template is="dom-if" if="{{!isUnassignedGroup(item.Name$)}}">
-                    <button class="btn website-surface-groups-add btn-danger" title="Delete group" value="{{item.DeleteGroup$::click}}" onmousedown="++this.value;">
-                        <span class="glyphicon glyphicon-remove website-no-pointer-events"></span>
-                    </button>
-                </template>
+                <button class="btn website-surface-groups-add btn-danger" title="Delete group" value="{{item.DeleteGroup$::click}}" onmousedown="++this.value;">
+                    <span class="glyphicon glyphicon-remove website-no-pointer-events"></span>
+                </button>
             </h4>
             <template is="dom-repeat" items="{{item.Surfaces}}" as="surface">
                 <a href="/WebsiteEditor/surface/{{surface.Key}}/general" class="website-surface-groups-surface">{{surface.Name}}</a>
             </template>
             <hr/>
         </template>
+
+        <!-- For unassigned surfaces -->
+        <h4>
+            <label class="website-surface-group-name">Unassigned</label>
+            <button class="btn website-surface-groups-add btn-success" title="Add new unassigned surface" value="{{model.CreateUnassignedSurface$::click}}" onmousedown="++this.value;">
+                <span class="glyphicon glyphicon-plus website-no-pointer-events"></span>
+            </button>
+        </h4>
+        <template is="dom-repeat" items="{{model.UnassignedSurfaces}}" as="surface">
+            <a href="/WebsiteEditor/surface/{{surface.Key}}/general" class="website-surface-groups-surface">{{surface.Name}}</a>
+        </template>
+        <hr/>
+
         <button class="btn btn-success" value="{{model.CreateGroup$::click}}" onmousedown="++this.value">Add Group</button>
     </template>
     <script>


### PR DESCRIPTION
Fixes #164 

After this fix, there is no more unassigned as a group, which was pretty confusing. Instead, surfaces with null value in WebTemplateGroup field are meant as unassigned. 